### PR TITLE
fix: update issue template GitHub link

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ f_is.write("---\n")
 f_is.write("title: Latest {0} Papers - {1}\n".format(issues_result, get_daily_date()))
 f_is.write("labels: documentation\n")
 f_is.write("---\n")
-f_is.write("**Please check the [Github](https://github.com/zezhishao/MTS_Daily_ArXiv) page for a better reading experience and more papers.**\n\n")
+f_is.write("**Please check the [GitHub](https://github.com/Luowaterbi/DailyArXiv) page for a better reading experience and more papers.**\n\n")
 
 for keyword in keywords:
     f_rm.write("## {0}\n".format(keyword))


### PR DESCRIPTION
## Summary
- update the issue template footer to point to this repository
- normalize the link text to `GitHub`

Fixes #416

## Testing
- `python3 -m py_compile main.py utils.py`
- `git diff --check`
- `python3 - <<'PY' ...` link assertion confirming the new repository URL is present and the old one is absent
